### PR TITLE
Replace `jsnext:main` with `module`

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "url": "http://bost.ocks.org/mike"
   },
   "main": "build/d3-selection-multi.js",
+  "jsnext:main": "index",
   "module": "index",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "url": "http://bost.ocks.org/mike"
   },
   "main": "build/d3-selection-multi.js",
-  "jsnext:main": "index",
+  "module": "index",
   "repository": {
     "type": "git",
     "url": "https://github.com/d3/d3-selection-multi.git"


### PR DESCRIPTION
[`jsnext:main` has been superceded](https://github.com/rollup/rollup/wiki/jsnext:main) by [`module`](https://github.com/rollup/rollup/wiki/pkg.module)

refs #11 