### PR TITLE
Rimraf instead of direct rm-rf

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "eslint": "3",
     "jsdom": "9",
     "package-preamble": "0.0",
-    "rimraf": "^2.6.1",
+    "rimraf": "2",
     "rollup": "0.41",
     "tape": "4",
     "uglify-js": "2"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/d3/d3-selection-multi.git"
   },
   "scripts": {
-    "pretest": "rm -rf build && mkdir build && rollup --banner \"$(preamble)\" -f umd -g d3-selection:d3,d3-transition:d3 -n d3 -o build/d3-selection-multi.js -- index.js",
+    "pretest": "rimraf build && mkdir build && rollup --banner \"$(preamble)\" -f umd -g d3-selection:d3,d3-transition:d3 -n d3 -o build/d3-selection-multi.js -- index.js",
     "test": "tape 'test/**/*-test.js' && eslint index.js src",
     "prepublish": "npm run test && uglifyjs --preamble \"$(preamble)\" build/d3-selection-multi.js -c -m -o build/d3-selection-multi.min.js",
     "postpublish": "git push && git push --tags && cd ../d3.github.com && git pull && cp ../d3-selection-multi/build/d3-selection-multi.js d3-selection-multi.v1.js && cp ../d3-selection-multi/build/d3-selection-multi.min.js d3-selection-multi.v1.min.js && git add d3-selection-multi.v1.js d3-selection-multi.v1.min.js && git commit -m \"d3-selection-multi ${npm_package_version}\" && git push && cd - && zip -j build/d3-selection-multi.zip -- LICENSE README.md build/d3-selection-multi.js build/d3-selection-multi.min.js"
@@ -35,6 +35,7 @@
     "eslint": "3",
     "jsdom": "9",
     "package-preamble": "0.0",
+    "rimraf": "^2.6.1",
     "rollup": "0.41",
     "tape": "4",
     "uglify-js": "2"


### PR DESCRIPTION
This PR is in regards of issue #13 - build not working on windows. Though maybe not absolutely required, I think it can be useful for this to work, as people (well, at least me...) could try and bundle d3-selection-multi on a Windows based machine. Plus, It makes things more consistent with other modules :-)